### PR TITLE
reference only: add rename guard feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "activationEvents": [
     "onCommand:rename-angular-component.renameComponent",
     "onCommand:rename-angular-component.renameDirective",
-    "onCommand:rename-angular-component.renameService"
+    "onCommand:rename-angular-component.renameService",
+    "onCommand:rename-angular-component.renameGuard"
   ],
   "extensionKind": [
     "ui",
@@ -55,6 +56,10 @@
       {
         "command": "rename-angular-component.renameService",
         "title": "Rename Angular Service"
+      },
+      {
+        "command": "rename-angular-component.renameGuard",
+        "title": "Rename Angular Route Guard"
       }
     ],
     "menus": {
@@ -72,6 +77,11 @@
         {
           "when": "resourceFilename =~ /^.+\\.service\\.(spec.ts|ts)$/",
           "command": "rename-angular-component.renameService",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceFilename =~ /^.+\\.guard\\.(spec.ts|ts)$/",
+          "command": "rename-angular-component.renameGuard",
           "group": "navigation"
         }
       ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,6 +58,12 @@ export function activate(context: vscode.ExtensionContext) {
     (uri: vscode.Uri) => renamer.rename('service', uri)
   );
   context.subscriptions.push(renameService);
+
+  let renameGuard = vscode.commands.registerCommand(
+    'rename-angular-component.renameGuard',
+    (uri: vscode.Uri) => renamer.rename('guard', uri)
+  );
+  context.subscriptions.push(renameGuard);
 }
 
 export function deactivate() {}

--- a/src/rename-angular-component/definitions/constructs-with-selectors.ts
+++ b/src/rename-angular-component/definitions/constructs-with-selectors.ts
@@ -1,0 +1,1 @@
+export const CONSTRUCTS_WITH_SELECTORS = ['component', 'directive'];

--- a/src/rename-angular-component/definitions/file-regex.constants.ts
+++ b/src/rename-angular-component/definitions/file-regex.constants.ts
@@ -1,10 +1,12 @@
 export const componentRegexPartial = `(?=\\.component\\.(spec\\.ts|scss|html|ts)$)`;
 export const directiveRegexPartial = `(?=\\.directive\\.(spec.ts|ts)$)`;
 export const serviceRegexPartial = `(?=\\.service\\.(spec.ts|ts)$)`;
+export const guardRegexPartial = `(?=\\.guard\\.(spec.ts|ts)$)`;
 export const anyConstructRegexPartial = `(?=.+\\.(spec\.ts|scss|html|ts)$)`;
 export const likeFilesRegexPartialLookup: { [key: string]: string } = {
   component: componentRegexPartial,
   directive: directiveRegexPartial,
   service: serviceRegexPartial,
+  guard: guardRegexPartial,
   any: anyConstructRegexPartial,
 };

--- a/src/rename-angular-component/definitions/file.interfaces.ts
+++ b/src/rename-angular-component/definitions/file.interfaces.ts
@@ -1,4 +1,10 @@
-export type AngularConstruct = 'component' | 'directive' | 'service' | 'module';
+export type AngularConstruct =
+  | 'component'
+  | 'directive'
+  | 'service'
+  | 'module'
+  | 'guard';
+
 export interface OriginalFileDetails {
   path: string;
   file: string;

--- a/src/rename-angular-component/in-file-edits/get-original-class-name.function.ts
+++ b/src/rename-angular-component/in-file-edits/get-original-class-name.function.ts
@@ -2,6 +2,7 @@ import * as ts from 'typescript';
 import { AngularConstruct } from '../definitions/file.interfaces';
 import * as fs from 'fs-extra-promise';
 import { classify } from '../../angular-cli/strings';
+import { CONSTRUCTS_WITH_SELECTORS } from '../definitions/constructs-with-selectors';
 
 export async function getOriginalClassName(
   stub: string,
@@ -18,8 +19,9 @@ export async function getOriginalClassName(
   );
 
   const classNamesFound: string[] = [];
-  const decoratorName =
-    construct === 'service' ? 'Injectable' : classify(construct);
+  const decoratorName = CONSTRUCTS_WITH_SELECTORS.includes(construct)
+    ? classify(construct)
+    : 'Injectable';
 
   for (const node of file.statements) {
     // get class

--- a/src/rename-angular-component/in-file-edits/get-original-file-details.function.ts
+++ b/src/rename-angular-component/in-file-edits/get-original-file-details.function.ts
@@ -10,7 +10,7 @@ export function getOriginalFileDetails(filePath: string): OriginalFileDetails {
 
   const file = filePath.substr(lastSlash + 1, filePath.length - lastSlash - 1);
   const stub = file.split(
-    /\.(component|directive|service)\.(spec.ts|scss|html|ts)$/
+    /\.(component|directive|service|guard)\.(spec.ts|scss|html|ts)$/
   )[0];
   return { path, file, stub, filePath };
 }

--- a/src/rename-angular-component/renamer.class.ts
+++ b/src/rename-angular-component/renamer.class.ts
@@ -25,6 +25,7 @@ import { getOriginalClassName } from './in-file-edits/get-original-class-name.fu
 import { DebugLogger } from './logging/debug-logger.class';
 import { validateHtmlSelector } from '../angular-cli/validation';
 import { classify, dasherize } from '../angular-cli/strings';
+import { CONSTRUCTS_WITH_SELECTORS } from './definitions/constructs-with-selectors';
 
 const timeoutPause = async (wait = 0) => {
   await new Promise((res) => setTimeout(res, wait));
@@ -32,7 +33,6 @@ const timeoutPause = async (wait = 0) => {
 };
 
 export class Renamer {
-  readonly constructsWithSelectors = ['component', 'directive'];
   private construct!: AngularConstruct;
   private title!: string;
   private originalFileDetails!: Readonly<OriginalFileDetails>;
@@ -83,9 +83,6 @@ export class Renamer {
           await this.updateSelectorsInTemplates();
 
           /* TODO 
-
-          Class name exported by barrel in same directory fails to update
-          Confirm when file watcher triggers reindex
 
           Fix MD files
             Readme has missing line break for ### 1.0.3
@@ -175,7 +172,7 @@ export class Renamer {
 
   private async updateSelectorsInTemplates() {
     // update selectors for components and directives
-    if (this.constructsWithSelectors.includes(this.construct)) {
+    if (CONSTRUCTS_WITH_SELECTORS.includes(this.construct)) {
       if (
         this.selectorTransfer.oldSelector &&
         this.selectorTransfer.newSelector


### PR DESCRIPTION
Reference: changes currently needed to add a new Angular construct to the rename list.
Thought: could be simplified to build regexes with Construct