### PR TITLE
Feat/rename modules basic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,51 +1,8 @@
 # Change Log
 
-## [Unreleased]
+## [2.1.0] - 2022-07-07
 
-- started 2021-07-23
-
-## [1.0.0] - 2021-12-27
-
-- Initial release
-  MVP (needs extensive cleanup refactor)
-
-## [1.0.1] - 2021-12-29
-
-- Bug fix: Discover original Class Name rather than predict it
-
-## [1.0.2] - 2022-01-04
-
-- Feature: Add optional debug log to file for issue creation
-- Refactor: Migrate Renamer code into class
-
-## [1.0.3] - 2022-01-07
-
-- Bug fix: SCSS file './' type @imports affected by move process
-- Bug fix: multi level inheritance in tsconfigs to pick up paths and baseUrl
-
-## [1.0.4] - 2022-01-13
-
-- Refactor: Use Angular CLI's own validation and string-case manipulation functions for Component name
-
-## [1.0.5] - 2022-01-17
-
-- Feature: Improved feedback for unexpected selector
-
-## [1.0.6] - 2022-02-03
-
-- Feature: Add support for direct, local path replacements when longer wildcard path is available.
-- Feature: Add support for rename Route Guards
-
-## [1.0.7] - 2022-02-03
-
-- Fix: Local Windows file path should be Unix format
-
-## [1.1.0] - 2022-02-21
-
-- Feature: Add compatibility with Nx Workspaces and projects that use layers of wildcard export barrels
-- Fix: Edge case race condition on imports changed in component and spec file
-- Fix: Edge case replacement of selectors missed in some templates due to line break in end tag
-- Fix: Replace dots with dashes entered for name
+- Feature: Add Rename Modules option
 
 ## [2.0.0] - 2022-03-29
 
@@ -54,3 +11,50 @@
 - Fix: Rename directive input attribute if it matches the current selector
 - Fix: Tsmove bug; handle fixed path rules in get relative path
 - Feature: Add integration testing capability using Git diff snapshots
+
+## [1.1.0] - 2022-02-21
+
+- Feature: Add compatibility with Nx Workspaces and projects that use layers of wildcard export barrels
+- Fix: Edge case race condition on imports changed in component and spec file
+- Fix: Edge case replacement of selectors missed in some templates due to line break in end tag
+- Fix: Replace dots with dashes entered for name
+
+## [1.0.7] - 2022-02-03
+
+- Fix: Local Windows file path should be Unix format
+
+## [1.0.6] - 2022-02-03
+
+- Feature: Add support for direct, local path replacements when longer wildcard path is available.
+- Feature: Add support for rename Route Guards
+
+## [1.0.5] - 2022-01-17
+
+- Feature: Improved feedback for unexpected selector
+
+## [1.0.4] - 2022-01-13
+
+- Refactor: Use Angular CLI's own validation and string-case manipulation functions for Component name
+
+## [1.0.3] - 2022-01-07
+
+- Bug fix: SCSS file './' type @imports affected by move process
+- Bug fix: multi level inheritance in tsconfigs to pick up paths and baseUrl
+
+## [1.0.2] - 2022-01-04
+
+- Feature: Add optional debug log to file for issue creation
+- Refactor: Migrate Renamer code into class
+
+## [1.0.1] - 2021-12-29
+
+- Bug fix: Discover original Class Name rather than predict it
+
+## [1.0.0] - 2021-12-27
+
+- Initial release
+  MVP (needs extensive cleanup refactor)
+
+## [Unreleased]
+
+- started 2021-07-23

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently works with these Angular features:
 - directives
 - services
 - guards
-- coming soon: modules
+- modules
 
 ## How to use
 
@@ -51,7 +51,8 @@ This extension contributes the following settings:
 ## Known Issues
 
 1. [Add flow for unexpected Selector name](https://github.com/tomwhite007/rename-angular-component/issues/13)
-1. [Add renamer process for Angular modules](https://github.com/tomwhite007/rename-angular-component/issues/26)
+1. [Naming Convention Problem (cannot reproduce)](https://github.com/tomwhite007/rename-angular-component/issues/29)
+1. [Extension does not support WSL](https://github.com/tomwhite007/rename-angular-component/issues/28)
 
 ## Support
 
@@ -69,10 +70,6 @@ Thanks to you for reading this.
 
 ## Release Notes
 
-Latest version: [2.0.0] - 2022-03-29
+Latest version: [2.1.0] - 2022-07-07
 
-- Feature: Add lazy loaded route imports to renamer process
-- Feature: Rename selectors in .spec files, inline component templates and Storybook .stories files
-- Fix: Rename directive input attribute if it matches the current selector
-- Fix: Tsmove bug; handle fixed path rules in get relative path
-- Feature: Add integration testing capability using Git diff snapshots
+- Feature: Add Rename Modules option

--- a/package-lock.json
+++ b/package-lock.json
@@ -2948,9 +2948,9 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.3.0.tgz",
-      "integrity": "sha512-K9qcbbZwPHhk7MLi0k0ekvSFXJIrRoXgHhqMXAFM75qS68vdHTcuzmul1ilKI02F/4lXshVgBoDll2t++JK0PQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.7.1.tgz",
+      "integrity": "sha512-+Osjtsumbtew2y9to0pOYjNzSIr4NkKGBg7Po5SUtjQhaJf2QBmiTX/9E9cv9rmc7oUiSGFIB9e7ys5ibnT9+A==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
@@ -5738,9 +5738,9 @@
       "dev": true
     },
     "simple-git": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.3.0.tgz",
-      "integrity": "sha512-K9qcbbZwPHhk7MLi0k0ekvSFXJIrRoXgHhqMXAFM75qS68vdHTcuzmul1ilKI02F/4lXshVgBoDll2t++JK0PQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.7.1.tgz",
+      "integrity": "sha512-+Osjtsumbtew2y9to0pOYjNzSIr4NkKGBg7Po5SUtjQhaJf2QBmiTX/9E9cv9rmc7oUiSGFIB9e7ys5ibnT9+A==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint": "^8.6.0",
         "glob": "^7.2.0",
         "mocha": "^9.1.3",
-        "simple-git": "^3.3.0",
+        "simple-git": "^3.7.1",
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.4",
         "vscode-test": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "onCommand:rename-angular-component.renameComponent",
     "onCommand:rename-angular-component.renameDirective",
     "onCommand:rename-angular-component.renameService",
-    "onCommand:rename-angular-component.renameGuard"
+    "onCommand:rename-angular-component.renameGuard",
+    "onCommand:rename-angular-component.renameModule"
   ],
   "extensionKind": [
     "ui",
@@ -60,6 +61,10 @@
       {
         "command": "rename-angular-component.renameGuard",
         "title": "Rename Angular Route Guard"
+      },
+      {
+        "command": "rename-angular-component.renameModule",
+        "title": "Rename Angular Module"
       }
     ],
     "menus": {
@@ -82,6 +87,11 @@
         {
           "when": "resourceFilename =~ /^.+\\.guard\\.(spec.ts|ts)$/",
           "command": "rename-angular-component.renameGuard",
+          "group": "navigation"
+        },
+        {
+          "when": "resourceFilename =~ /^.+\\.module\\.(spec.ts|ts)$/",
+          "command": "rename-angular-component.renameModule",
           "group": "navigation"
         }
       ]
@@ -128,7 +138,7 @@
     "eslint": "^8.6.0",
     "glob": "^7.2.0",
     "mocha": "^9.1.3",
-    "simple-git": "^3.3.0",
+    "simple-git": "^3.7.1",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.4",
     "vscode-test": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rename Angular Component",
   "description": "Rename Angular Components, Directives and Services",
   "publisher": "tomwhite007",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,29 +41,40 @@ export function activate(context: vscode.ExtensionContext) {
     debugLogger
   );
 
-  let renameComponent = vscode.commands.registerCommand(
-    'rename-angular-component.renameComponent',
-    async (uri: vscode.Uri) => renamer.rename('component', uri)
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'rename-angular-component.renameComponent',
+      async (uri: vscode.Uri) => renamer.rename('component', uri)
+    )
   );
-  context.subscriptions.push(renameComponent);
 
-  let renameDirective = vscode.commands.registerCommand(
-    'rename-angular-component.renameDirective',
-    (uri: vscode.Uri) => renamer.rename('directive', uri)
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'rename-angular-component.renameDirective',
+      (uri: vscode.Uri) => renamer.rename('directive', uri)
+    )
   );
-  context.subscriptions.push(renameDirective);
 
-  let renameService = vscode.commands.registerCommand(
-    'rename-angular-component.renameService',
-    (uri: vscode.Uri) => renamer.rename('service', uri)
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'rename-angular-component.renameService',
+      (uri: vscode.Uri) => renamer.rename('service', uri)
+    )
   );
-  context.subscriptions.push(renameService);
 
-  let renameGuard = vscode.commands.registerCommand(
-    'rename-angular-component.renameGuard',
-    (uri: vscode.Uri) => renamer.rename('guard', uri)
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'rename-angular-component.renameGuard',
+      (uri: vscode.Uri) => renamer.rename('guard', uri)
+    )
   );
-  context.subscriptions.push(renameGuard);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'rename-angular-component.renameModule',
+      (uri: vscode.Uri) => renamer.rename('module', uri)
+    )
+  );
 }
 
 export function deactivate() {}

--- a/src/rename-angular-component/definitions/file-regex.constants.ts
+++ b/src/rename-angular-component/definitions/file-regex.constants.ts
@@ -1,12 +1,16 @@
-export const componentRegexPartial = `(?=\\.component\\.(spec\\.ts|scss|css|sass|less|html|ts)$)`;
-export const directiveRegexPartial = `(?=\\.directive\\.(spec.ts|ts)$)`;
-export const serviceRegexPartial = `(?=\\.service\\.(spec.ts|ts)$)`;
-export const guardRegexPartial = `(?=\\.guard\\.(spec.ts|ts)$)`;
-export const anyConstructRegexPartial = `(?=.+\\.(spec\.ts|scss|css|sass|less|html|ts)$)`;
+import { AngularConstruct } from './file.interfaces';
+
+const componentRegexPartial = `(?=\\.component\\.(spec\\.ts|scss|css|sass|less|html|ts)$)`;
+const generalRegexPartial = (construct: AngularConstruct) =>
+  `(?=\\.${construct}\\.(spec.ts|ts)$)`;
+const moduleRegexPartial = `(?=\\.module\\.(spec.ts|ts)$)`;
+
+const anyConstructRegexPartial = `(?=\\.[\\w\\-_]+\\.(spec\\.ts|scss|css|sass|less|html|ts)$)`;
 export const likeFilesRegexPartialLookup: { [key: string]: string } = {
   component: componentRegexPartial,
-  directive: directiveRegexPartial,
-  service: serviceRegexPartial,
-  guard: guardRegexPartial,
+  directive: generalRegexPartial('directive'),
+  service: generalRegexPartial('service'),
+  guard: generalRegexPartial('guard'),
+  module: moduleRegexPartial,
   any: anyConstructRegexPartial,
 };

--- a/src/rename-angular-component/file-manipulation/files-related-to-stub.class.ts
+++ b/src/rename-angular-component/file-manipulation/files-related-to-stub.class.ts
@@ -14,6 +14,12 @@ interface FileDetails {
   isCoreConstruct: boolean;
 }
 
+export interface FileToMove {
+  filePath: string;
+  newFilePath: string;
+  isCoreConstruct: boolean;
+}
+
 export class FilesRelatedToStub {
   originalFileDetails!: OriginalFileDetails;
   folderNameSameAsStub = false;

--- a/src/rename-angular-component/in-file-edits/get-core-file-path.function.ts
+++ b/src/rename-angular-component/in-file-edits/get-core-file-path.function.ts
@@ -1,0 +1,7 @@
+import { FileToMove } from '../file-manipulation/files-related-to-stub.class';
+
+export function getCoreFilePath(filesToMove: FileToMove[]) {
+  let coreConstructs = filesToMove.filter((f) => f.isCoreConstruct);
+  // TODO: add logic for handling core router modules
+  return coreConstructs[0]?.filePath;
+}

--- a/src/rename-angular-component/in-file-edits/get-decorator-name.function.ts
+++ b/src/rename-angular-component/in-file-edits/get-decorator-name.function.ts
@@ -1,0 +1,12 @@
+import { classify } from '../../angular-cli/strings';
+import { CONSTRUCTS_WITH_SELECTORS } from '../definitions/constructs-with-selectors';
+import { AngularConstruct } from '../definitions/file.interfaces';
+
+export function getDecoratorName(construct: AngularConstruct) {
+  if (construct === 'module') {
+    return 'NgModule';
+  }
+  return CONSTRUCTS_WITH_SELECTORS.includes(construct)
+    ? classify(construct)
+    : 'Injectable';
+}

--- a/src/rename-angular-component/in-file-edits/get-original-class-name.function.ts
+++ b/src/rename-angular-component/in-file-edits/get-original-class-name.function.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 import { AngularConstruct } from '../definitions/file.interfaces';
 import * as fs from 'fs-extra-promise';
 import { classify } from '../../angular-cli/strings';
-import { CONSTRUCTS_WITH_SELECTORS } from '../definitions/constructs-with-selectors';
+import { getDecoratorName } from './get-decorator-name.function';
 
 export async function getOriginalClassName(
   stub: string,
@@ -19,9 +19,7 @@ export async function getOriginalClassName(
   );
 
   const classNamesFound: string[] = [];
-  const decoratorName = CONSTRUCTS_WITH_SELECTORS.includes(construct)
-    ? classify(construct)
-    : 'Injectable';
+  const decoratorName = getDecoratorName(construct);
 
   for (const node of file.statements) {
     // get class

--- a/src/rename-angular-component/in-file-edits/get-original-file-details.function.ts
+++ b/src/rename-angular-component/in-file-edits/get-original-file-details.function.ts
@@ -10,7 +10,7 @@ export function getOriginalFileDetails(filePath: string): OriginalFileDetails {
 
   const file = filePath.substr(lastSlash + 1, filePath.length - lastSlash - 1);
   const stub = file.split(
-    /\.(component|directive|service|guard)\.(spec.ts|scss|css|sass|less|html|ts)$/
+    /\.(component|directive|service|guard|module)\.(spec.ts|scss|css|sass|less|html|ts)$/
   )[0];
   return { path, file, stub, filePath };
 }

--- a/src/test/suite/diffs/test-rename-spa.txt
+++ b/src/test/suite/diffs/test-rename-spa.txt
@@ -175,7 +175,7 @@ index ca2efdc..7a02a90 100644
  })
  export class SharedModule {}
 diff --git a/src/app/app-routing.module.ts b/src/app/app-routing.module.ts
-index a81169d..e488329 100644
+index a81169d..e1ed888 100644
 --- a/src/app/app-routing.module.ts
 +++ b/src/app/app-routing.module.ts
 @@ -5,7 +5,7 @@ const routes: Routes = [
@@ -183,7 +183,7 @@ index a81169d..e488329 100644
      path: 'products',
      loadChildren: () =>
 -      import('./products/products.module').then((m) => m.ProductsModule),
-+      import('./tom-test/products.module').then((m) => m.ProductsModule),
++      import('./tom-test/tom-test.module').then((m) => m.TomTestModule),
    },
  ];
  
@@ -237,27 +237,6 @@ index 72d8bd3..0bd5c33 100644
  
  @NgModule({
    imports: [RouterModule.forChild(routes)],
-diff --git a/src/app/products/products.module.ts b/src/app/tom-test/products.module.ts
-similarity index 76%
-rename from src/app/products/products.module.ts
-rename to src/app/tom-test/products.module.ts
-index a2fe432..8c8db38 100644
---- a/src/app/products/products.module.ts
-+++ b/src/app/tom-test/products.module.ts
-@@ -2,11 +2,11 @@ import { NgModule } from '@angular/core';
- import { CommonModule } from '@angular/common';
- 
- import { ProductsRoutingModule } from './products-routing.module';
--import { ProductsComponent } from './products.component';
-+import { TomTestComponent } from './tom-test.component';
- import { SharedModule } from '@shared';
- 
- @NgModule({
--  declarations: [ProductsComponent],
-+  declarations: [TomTestComponent],
-   imports: [CommonModule, ProductsRoutingModule, SharedModule],
- })
- export class ProductsModule {}
 diff --git a/src/app/tom-test/tom-test.component.html b/src/app/tom-test/tom-test.component.html
 new file mode 100644
 index 0000000..014f286
@@ -327,3 +306,25 @@ index 0000000..c4a0e53
 +  }
 +
 +}
+diff --git a/src/app/products/products.module.ts b/src/app/tom-test/tom-test.module.ts
+similarity index 68%
+rename from src/app/products/products.module.ts
+rename to src/app/tom-test/tom-test.module.ts
+index a2fe432..090ba81 100644
+--- a/src/app/products/products.module.ts
++++ b/src/app/tom-test/tom-test.module.ts
+@@ -2,11 +2,11 @@ import { NgModule } from '@angular/core';
+ import { CommonModule } from '@angular/common';
+ 
+ import { ProductsRoutingModule } from './products-routing.module';
+-import { ProductsComponent } from './products.component';
++import { TomTestComponent } from './tom-test.component';
+ import { SharedModule } from '@shared';
+ 
+ @NgModule({
+-  declarations: [ProductsComponent],
++  declarations: [TomTestComponent],
+   imports: [CommonModule, ProductsRoutingModule, SharedModule],
+ })
+-export class ProductsModule {}
++export class TomTestModule {}

--- a/src/test/suite/scenario5.test.ts
+++ b/src/test/suite/scenario5.test.ts
@@ -31,6 +31,11 @@ suite('Suite Scenario 5', () => {
           construct: 'directive',
           newStub: 'dir-identifier',
         },
+        {
+          filePath: './src/app/tom-test/products.module.ts',
+          construct: 'module',
+          newStub: 'tom-test',
+        },
       ],
       fileDiffPath: './src/test/suite/diffs/test-rename-spa.txt',
     });


### PR DESCRIPTION
Rename Modules feature.

Basic implementation because rename sibling routing module at the same time causes too many breaking changes for now. Instead, user can right-click and rename that file afterwards.