### PR TITLE
Fix/case insensitive drive path on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [2.1.3] - 2022-07-29
+## [2.1.3] - 2022-08-08
 
 - Fix: Case insensitive drive letter for Windows (for non default)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [2.1.3] - 2022-07-29
+
+- Fix: Case insensitive drive letter for Windows (for non default)
+
 ## [2.1.2] - 2022-07-11
 
 - Logging: Add debug logging of glob for issue 29 (all logging is optional)

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ This extension contributes the following settings:
 ## Known Issues
 
 1. [Add flow for unexpected Selector name](https://github.com/tomwhite007/rename-angular-component/issues/13)
-1. [Naming Convention Problem (cannot reproduce)](https://github.com/tomwhite007/rename-angular-component/issues/29)
 1. [Extension does not support WSL](https://github.com/tomwhite007/rename-angular-component/issues/28)
+1. [Rename service class names inside test files](https://github.com/tomwhite007/rename-angular-component/issues/34)
 
 ## Support
 
@@ -70,6 +70,6 @@ Thanks to you for reading this.
 
 ## Release Notes
 
-Latest version: [2.1.3] - 2022-07-29
+Latest version: [2.1.3] - 2022-08-08
 
 - Fix: Case insensitive drive letter for Windows (for non default)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ Thanks to you for reading this.
 
 ## Release Notes
 
-Latest version: [2.1.2] - 2022-07-11
+Latest version: [2.1.3] - 2022-07-29
 
-- Logging: Add debug logging of glob for issue 29 (all logging is optional)
+- Fix: Case insensitive drive letter for Windows (for non default)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rename Angular Component",
   "description": "Rename Angular Components, Directives and Services",
   "publisher": "tomwhite007",
-  "version": "2.1.3-rc.1",
+  "version": "2.1.3-rc.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rename Angular Component",
   "description": "Rename Angular Components, Directives and Services",
   "publisher": "tomwhite007",
-  "version": "2.1.3-rc.2",
+  "version": "2.1.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Rename Angular Component",
   "description": "Rename Angular Components, Directives and Services",
   "publisher": "tomwhite007",
-  "version": "2.1.2",
+  "version": "2.1.3-rc.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/rename-angular-component/file-manipulation/windows-file-path-fix.function.ts
+++ b/src/rename-angular-component/file-manipulation/windows-file-path-fix.function.ts
@@ -1,5 +1,5 @@
 export function windowsFilePathFix(path: string, backSlash = false) {
-  const windowsDriveMatch = path.match(/^\/[a-z]:/) || path.match(/^[a-z]:/i);
+  const windowsDriveMatch = path.match(/^\/[a-z]:/i) || path.match(/^[a-z]:/i);
   if (windowsDriveMatch) {
     path = path.replace(/^\//, '');
     if (backSlash) {

--- a/src/rename-angular-component/file-manipulation/windows-file-path-fix.function.ts
+++ b/src/rename-angular-component/file-manipulation/windows-file-path-fix.function.ts
@@ -1,6 +1,10 @@
 export function windowsFilePathFix(path: string, backSlash = false) {
   const windowsDriveMatch = path.match(/^\/[a-z]:/i) || path.match(/^[a-z]:/i);
   if (windowsDriveMatch) {
+    path = path.replace(
+      windowsDriveMatch[0],
+      windowsDriveMatch[0].toLocaleLowerCase()
+    );
     path = path.replace(/^\//, '');
     if (backSlash) {
       path = path.replace(/\//g, '\\');

--- a/src/rename-angular-component/renamer.class.ts
+++ b/src/rename-angular-component/renamer.class.ts
@@ -82,15 +82,17 @@ export class Renamer {
 
           /* TODO 
 
-          fix up import identifier in core module for routing.module
+          Windows: replacement ts wildcard path seems to fail in some jest unit tests
+
+          replace selector inside snapshot files
+
+          replace class name in all strings in test files - Aris issue
 
           ---- v2 ----- 
   
           limit rename selector in templates to current workspace multi-folder root
   
           refactor for clean classes, functions and pure async await
-  
-          fix up / remove tsmove conf() configuration
   
           ---- v3 -----
         */

--- a/src/test/suite/scenario1.test.ts
+++ b/src/test/suite/scenario1.test.ts
@@ -1,8 +1,23 @@
+import assert = require('assert');
+import path = require('path');
 import * as vscode from 'vscode';
+import { windowsFilePathFix } from '../../rename-angular-component/file-manipulation/windows-file-path-fix.function';
 import { genericTestScenario } from './helpers/generic-test-scenario.function';
 
 suite('Suite Scenario 1', () => {
   vscode.window.showInformationMessage('Start all tests.');
+
+  test('Drive path tests for Windows', () => {
+    const testPath1 = 'C:/Users/TomWhite/dev/test1';
+    const testPath2 = '/C:/Users/TomWhite/dev/test2';
+    const testPath3 = 'c:\\Users\\TomWhite\\dev\\test3';
+
+    const expected = 'c:/Users/TomWhite/dev/test';
+
+    assert.strictEqual(windowsFilePathFix(testPath1), expected + '1');
+    assert.strictEqual(windowsFilePathFix(testPath2), expected + '2');
+    assert.strictEqual(windowsFilePathFix(testPath3), expected + '3');
+  });
 
   test('Scenario 1', async () => {
     /*


### PR DESCRIPTION
Under some conditions, `fs` and `vscode.workspace.fs` return different cases for the same drive letter. This patch makes the renamer code case insensitive.