### PR TITLE
feat: add trigger rename with shortcut

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rename-angular-component",
-  "version": "3.0.0-alpha-2",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rename-angular-component",
-      "version": "3.0.0-alpha-2",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "bluebird": "^3.7.2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,13 @@
 import * as vscode from 'vscode';
 
 import { ReferenceIndexBuilder } from './move-ts-indexer/reference-index-builder';
-import { UserMessage } from './rename-angular-component/logging/user-message.class';
 import { EXTENSION_NAME } from './rename-angular-component/definitions/extension-name';
-import { Renamer } from './rename-angular-component/renamer.class';
-import { DebugLogger } from './rename-angular-component/logging/debug-logger.class';
 import { getConfig } from './rename-angular-component/definitions/getConfig.function';
+import { DebugLogger } from './rename-angular-component/logging/debug-logger.class';
+import { UserMessage } from './rename-angular-component/logging/user-message.class';
+import { Renamer } from './rename-angular-component/renamer.class';
+import { IsValid } from './utils/is-valid-uri';
+import { readFilePath } from './utils/read-file-path';
 
 export function activate(context: vscode.ExtensionContext) {
   const debugLogger = new DebugLogger(getConfig('debugLog', false));
@@ -44,7 +46,21 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'rename-angular-component.renameComponent',
-      async (uri: vscode.Uri) => renamer.rename('component', uri)
+      async (uri: vscode.Uri) => {
+        if (uri) {
+          return renamer.rename('component', uri);
+        }
+
+        const newUri = await readFilePath();
+
+        if (IsValid.componentUri(newUri)) {
+          return renamer.rename('component', vscode.Uri.file(newUri));
+        }
+
+        vscode.window.showInformationMessage(
+          'The selected file is not a component'
+        );
+      }
     )
   );
 

--- a/src/utils/is-valid-uri.ts
+++ b/src/utils/is-valid-uri.ts
@@ -1,0 +1,21 @@
+export class IsValid {
+  static componentUri(uri: string): boolean {
+    return /^.+\.component\.(spec.ts|scss|css|sass|less|html|ts)$/.test(uri);
+  }
+
+  static serviceUri(uri: string): boolean {
+    return /^.+\.service\.(spec.ts|ts)$/.test(uri);
+  }
+
+  static directiveUri(uri: string): boolean {
+    return /^.+\.directive\.(spec.ts|ts)$/.test(uri);
+  }
+
+  static guardUri(uri: string): boolean {
+    return /^.+\.guard\.(spec.ts|ts)$/.test(uri);
+  }
+
+  static moduleUri(uri: string): boolean {
+    return /^.+\.module\.(spec.ts|ts)$/.test(uri);
+  }
+}

--- a/src/utils/read-file-path.ts
+++ b/src/utils/read-file-path.ts
@@ -1,0 +1,9 @@
+import * as vscode from 'vscode';
+
+export async function readFilePath(): Promise<string> {
+  const originalClipboard = await vscode.env.clipboard.readText();
+  await vscode.commands.executeCommand('copyFilePath');
+  const newUri = await vscode.env.clipboard.readText();
+  await vscode.env.clipboard.writeText(originalClipboard);
+  return newUri;
+}


### PR DESCRIPTION
👋 Hi there!!

I have been using your extension and I love it! 

I would like to contribute and I want to show you my small idea.

I am one of those who doesn't like to touch his mouse very: much, so I love shortcuts. And I have been trying to figure out how to make your extension work without right-clicking the context menu.
I found a small trick other extension authors use, there is a way to copy the path of the selected file in your explorer, however the method copies the path in your clipboard. So they make a temporary copy of the clipboard, copy the path and then restore the clipboard as it was before.

```ts
import * as vscode from 'vscode';

export async function readFilePath(): Promise<string> {
  const originalClipboard = await vscode.env.clipboard.readText();
  await vscode.commands.executeCommand('copyFilePath');
  const newUri = await vscode.env.clipboard.readText();
  await vscode.env.clipboard.writeText(originalClipboard);
  return newUri;
}
```

This is an idea of how to make it work for components, and then if it's ok with you we can apply it to services, pipes, etc...

Just let me know what you think about it!! 😊:
